### PR TITLE
82 fixing cropping margins mobile

### DIFF
--- a/breast-cancer-hub/app/CustomizeExamDateScreen.tsx
+++ b/breast-cancer-hub/app/CustomizeExamDateScreen.tsx
@@ -159,6 +159,7 @@ const styles = StyleSheet.create({
   },
   titleContainer: {
     flexDirection: "column",
+    marginLeft: 20,
   },
   customizeYourText: {
     paddingTop: 20,
@@ -166,6 +167,7 @@ const styles = StyleSheet.create({
     color: colors.darkPink,
     fontWeight: "bold",
     paddingBottom: 10,
+    lineHeight: 35,
   },
   yourText: {
     fontSize: 29,
@@ -177,6 +179,7 @@ const styles = StyleSheet.create({
     color: colors.black,
     fontWeight: "bold",
     paddingBottom: 20,
+    lineHeight: 35,
   },
   bodyContainer: {
     flex: 1,
@@ -224,6 +227,7 @@ const styles = StyleSheet.create({
     color: colors.white,
     fontWeight: "bold",
     textAlign: "center",
+    lineHeight: 50,
   },
   chevronContainer: {
     flexDirection: "column",

--- a/breast-cancer-hub/app/CustomizeExamDateScreen.tsx
+++ b/breast-cancer-hub/app/CustomizeExamDateScreen.tsx
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     fontSize: 29,
     color: colors.black,
     fontWeight: "bold",
-    paddingBottom: 20,
+    paddingBottom: 10,
     lineHeight: 35,
   },
   bodyContainer: {

--- a/breast-cancer-hub/app/askMenstruate.tsx
+++ b/breast-cancer-hub/app/askMenstruate.tsx
@@ -182,7 +182,10 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   optionButton: {
-    width: "60%", // Made the button smaller
+    //width: "60%", // Made the button smaller
+    alignSelf: 'center',
+    paddingLeft: 15,
+    paddingRight: 15,
     backgroundColor: colors.backgroundLightGray,
     borderColor: colors.darkPink,
     borderWidth: 3,

--- a/breast-cancer-hub/app/index.tsx
+++ b/breast-cancer-hub/app/index.tsx
@@ -379,6 +379,8 @@ const styles = StyleSheet.create({
     fontSize: 29,
     fontWeight: "bold",
     color: colors.black,
+    lineHeight: 30,
+    
   },
   nameText: {
     fontSize: 29,

--- a/breast-cancer-hub/app/index.tsx
+++ b/breast-cancer-hub/app/index.tsx
@@ -88,7 +88,6 @@ export default function HomeScreen(props: HomeScreenProps) {
               source={require("../assets/images/BCH-Logo-Stacked-CMYK.png")}
               style={styles.logo}
             />
-            <ThemedText style={styles.homeText}>Home</ThemedText>
           </View>
           {/* Profile Icon */}
           <TouchableOpacity
@@ -355,6 +354,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   logoHomeContainer: {
+    padding:10,
     flexDirection: "row",
     alignItems: "center",
   },
@@ -396,17 +396,16 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   contentContainer: {
-    // Removed horizontal padding so pink footer can extend edge-to-edge
     paddingTop: 20,
   },
   mainContent: {
-    // We wrap main content here so it has horizontal padding
+    paddingTop:40,
     paddingHorizontal: 20,
   },
   introLine: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 30, // replaced 10 + 20
+    marginBottom: 30, 
   },
   icon: {
     marginRight: 10,

--- a/breast-cancer-hub/app/settings.tsx
+++ b/breast-cancer-hub/app/settings.tsx
@@ -73,7 +73,7 @@ export default function SettingsScreen() {
 
             {/* Notification Preferences */}
             <TouchableOpacity
-              style={[styles.optionContainer, {height: 1}]}
+              style={styles.optionContainer}
               onPress={() => router.push("./settingsNotifications")}
             >
               <ThemedText style={styles.optionText}>
@@ -83,7 +83,7 @@ export default function SettingsScreen() {
             </TouchableOpacity>
 
             {/* Change Self Examination Language */}
-            <TouchableOpacity style={[styles.optionContainer, {height: 1}]}>
+            <TouchableOpacity style={styles.optionContainer}>
               <ThemedText style={styles.optionText}>
                 Change Self Examination Language
               </ThemedText>
@@ -91,7 +91,7 @@ export default function SettingsScreen() {
             </TouchableOpacity>
 
             {/* Telemetry */}
-            <View style={[styles.optionContainer, {height: 1}]}>
+            <View style={styles.optionContainer}>
               <ThemedText style={styles.optionText}>Telemetry</ThemedText>
               <Switch
                 trackColor={{ false: "#767577", true: colors.lightPink }}
@@ -103,7 +103,7 @@ export default function SettingsScreen() {
             </View>
 
             {/* Backup */}
-            <View style={[styles.optionContainer, {height: 1}]}>
+            <View style={styles.optionContainer}>
               <ThemedText style={styles.optionText}>Backup</ThemedText>
               <Switch
                 trackColor={{ false: "#767577", true: colors.lightPink }}
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     paddingTop: "15%", 
-    paddingHorizontal: 20,
+    paddingHorizontal: "6%",
     marginBottom: "8%",
   },
   backButton: {
@@ -215,7 +215,7 @@ const styles = StyleSheet.create({
   userInfoContainer: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: 30,
+    marginTop: 10,
   },
   userTextContainer: {
     flex: 1,
@@ -257,14 +257,13 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingVertical: 25,
+    paddingVertical: 10,
   },
   optionText: {
     fontSize: 15,
     color: colors.black,
-    flex: 1,
+    flex: 0.5,
     flexWrap: "wrap",
-    padding:30,
   },
   saveButton: {
     backgroundColor: colors.darkPink,

--- a/breast-cancer-hub/app/settings.tsx
+++ b/breast-cancer-hub/app/settings.tsx
@@ -14,13 +14,13 @@ import { useRouter } from "expo-router";
 import { getSetting } from "@/hooks/useSettings";
 import { colors } from "@/components/StyleSheet";
 
+
 export default function SettingsScreen() {
   const router = useRouter();
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = React.useState(false);
   const [isBackupEnabled, setIsBackupEnabled] = React.useState(false);
   const [isDarkModeEnabled, setIsDarkModeEnabled] = React.useState(false);
-
   const [person, setPerson] = useState({ name: "", email: "" });
 
   useEffect(() => {
@@ -177,9 +177,9 @@ const styles = StyleSheet.create({
   headerContainer: {
     flexDirection: "row",
     alignItems: "center",
-    paddingTop: 50,
+    paddingTop: "15%", 
     paddingHorizontal: 20,
-    marginBottom: 20,
+    marginBottom: "8%",
   },
   backButton: {
     backgroundColor: colors.darkPink,
@@ -194,6 +194,7 @@ const styles = StyleSheet.create({
     fontSize: 36,
     color: colors.darkPink,
     fontWeight: "bold",
+    lineHeight: 40,
   },
   contentContainer: {
     alignItems: "center",
@@ -256,13 +257,14 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingVertical: 10,
+    paddingVertical: 25,
   },
   optionText: {
     fontSize: 15,
     color: colors.black,
     flex: 1,
     flexWrap: "wrap",
+    padding:30,
   },
   saveButton: {
     backgroundColor: colors.darkPink,

--- a/breast-cancer-hub/app/settings.tsx
+++ b/breast-cancer-hub/app/settings.tsx
@@ -146,13 +146,13 @@ export default function SettingsScreen() {
             </View>
 
             {/* Change Date or Scheduling Type */}
-            <TouchableOpacity style={styles.optionContainer}>
-              <ThemedText
-                style={styles.optionText}
-                onPress={() => {
-                  router.push("/askMenstruate");
-                }}
-              >
+            <TouchableOpacity
+              style={styles.optionContainer}
+              onPress={() => {
+                router.push("/askMenstruate");
+              }}
+            >
+              <ThemedText style={styles.optionText}>
                 Change Date or Scheduling Type
               </ThemedText>
               <Ionicons name="chevron-forward" size={20} color={colors.black} />

--- a/breast-cancer-hub/app/settings.tsx
+++ b/breast-cancer-hub/app/settings.tsx
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     paddingTop: "15%", 
-    paddingHorizontal: "6%",
+    paddingHorizontal: "5%",
     marginBottom: "8%",
   },
   backButton: {
@@ -195,6 +195,7 @@ const styles = StyleSheet.create({
     color: colors.darkPink,
     fontWeight: "bold",
     lineHeight: 40,
+    margin: 10,
   },
   contentContainer: {
     alignItems: "center",

--- a/breast-cancer-hub/app/settingsNotifications.tsx
+++ b/breast-cancer-hub/app/settingsNotifications.tsx
@@ -197,6 +197,10 @@ const styles = StyleSheet.create({
     fontSize: 36,
     color: colors.darkPink,
     fontWeight: "bold",
+    lineHeight: 35,
+    marginTop: 20,
+    marginHorizontal: 10,
+    marginBottom: 10,
   },
   contentContainer: {
     alignItems: "center",

--- a/breast-cancer-hub/app/settingsProfile.tsx
+++ b/breast-cancer-hub/app/settingsProfile.tsx
@@ -102,25 +102,20 @@ const styles = StyleSheet.create({
     borderRadius: 20, // Circular
     alignItems: "center",
     justifyContent: "center",
-    marginRight: 10,
   },
   headerTitle: {
     fontSize: 36,
     color: colors.darkPink,
     fontWeight: "bold",
     lineHeight: 40,
-    marginTop:  5,
-    marginHorizontal: 2,
-    marginBottom: 5,
+    margin:  15,
   },
   mainContainer: {
     flex: 1, // Extend to the bottom
     width: "90%",
     backgroundColor: colors.white,
     borderRadius: 20,
-    paddingHorizontal: 40,
-    paddingTop: 40,
-    paddingBottom: 20, // Add padding at the bottom
+    padding: 40,
     alignSelf: "center",
     // Shadow
     shadowColor: "#000",

--- a/breast-cancer-hub/app/settingsProfile.tsx
+++ b/breast-cancer-hub/app/settingsProfile.tsx
@@ -91,9 +91,9 @@ const styles = StyleSheet.create({
   headerContainer: {
     flexDirection: "row",
     alignItems: "center",
-    paddingTop: "8%",
+    paddingTop: "15%",
     paddingHorizontal: 20,
-    marginBottom: "3%",
+    marginBottom: "5%",
   },
   backButton: {
     backgroundColor: colors.darkPink,
@@ -109,9 +109,9 @@ const styles = StyleSheet.create({
     color: colors.darkPink,
     fontWeight: "bold",
     lineHeight: 40,
-    marginTop: 30,
-    marginHorizontal: 10,
-    marginBottom: 20,
+    marginTop:  5,
+    marginHorizontal: 2,
+    marginBottom: 5,
   },
   mainContainer: {
     flex: 1, // Extend to the bottom

--- a/breast-cancer-hub/app/settingsProfile.tsx
+++ b/breast-cancer-hub/app/settingsProfile.tsx
@@ -91,9 +91,9 @@ const styles = StyleSheet.create({
   headerContainer: {
     flexDirection: "row",
     alignItems: "center",
-    paddingTop: 50,
+    paddingTop: "8%",
     paddingHorizontal: 20,
-    marginBottom: 20,
+    marginBottom: "3%",
   },
   backButton: {
     backgroundColor: colors.darkPink,
@@ -108,6 +108,10 @@ const styles = StyleSheet.create({
     fontSize: 36,
     color: colors.darkPink,
     fontWeight: "bold",
+    lineHeight: 40,
+    marginTop: 30,
+    marginHorizontal: 10,
+    marginBottom: 20,
   },
   mainContainer: {
     flex: 1, // Extend to the bottom

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "breast-cancer-hub",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
I fixed the issue where all the headings on the main page, settings page, and the setting subpages were getting cropped out by the top of the viewport. I also fixed the issue where the number that displays the day of the month in the date picker is cut off. The problem where the subpages within the general section were not showing up on the app is also fixed. I also adjusted margins and padding for all of the settings pages to look more presentable for the app. I also removed the "Home" text on the main page and fixed the alignment of the logo on the main page to look better.  