### PR TITLE
fixed the bug where we clear the old period data when user changes fr…

### DIFF
--- a/breast-cancer-hub/app/askMenstruate.tsx
+++ b/breast-cancer-hub/app/askMenstruate.tsx
@@ -5,6 +5,7 @@ import { ThemedView } from "@/components/ThemedView";
 import { useRouter } from "expo-router";
 import { saveSetting } from "@/hooks/useSettings";
 import { colors, globalStyles } from "@/components/StyleSheet";
+import { GLOBAL_PERIOD_DATA, initPeriods } from "@/hooks/usePeriodData";
 
 export default function MenstruationSelectionScreen() {
   const router = useRouter();
@@ -19,8 +20,9 @@ export default function MenstruationSelectionScreen() {
       // Navigate to index.tsx
       //router.back();
       if (selectedOption == "menstruate") {
+        // Save the setting and navigate to calendar
         saveSetting("schedulingType", "period").then(() => {
-          router.back();
+          router.push("/");
         });
       } else {
         router.push("/CustomizeExamDateScreen");

--- a/breast-cancer-hub/components/Calendar.tsx
+++ b/breast-cancer-hub/components/Calendar.tsx
@@ -39,6 +39,19 @@ export function CalendarComponent({
   const [periodDay, setPeriodDay] = useState<number>(28);
   const [_seed, setSeed] = useState(0);
 
+  // Full refresh function
+  const refreshCalendar = () => {
+    setCurrentDate(new Date());
+    setIsEditing(false);
+    setPeriodDay(28);
+    setSeed(Math.random());
+    initPeriods().then((original) => {
+      if (original) {
+        updateCheckupDay();
+      }
+    });
+  };
+
   useEffect(() => {
     getSetting("schedulingType").then((type) => {
       if (type != "period") {
@@ -55,6 +68,16 @@ export function CalendarComponent({
       }
     });
   }, []);
+
+  // Handle menstruation status changes
+  useEffect(() => {
+    if (isMenstruating) {
+      refreshCalendar();
+    } else {
+      setIsEditing(false);
+      setSeed(Math.random());
+    }
+  }, [isMenstruating]);
 
   const goToPreviousMonth = () => {
     setCurrentDate((prevDate) => {
@@ -128,7 +151,7 @@ export function CalendarComponent({
         p,
         date: daysInPrevMonth - i,
         inCurrentMonth: false,
-        isPeriodDay: isPeriodDay(p),
+        isPeriodDay: isMenstruating && isPeriodDay(p),
         isSpecialDay: isMenstruating
           ? isCheckupDay(p)
           : startingDay - 1 === periodDay,
@@ -145,7 +168,7 @@ export function CalendarComponent({
         p,
         date: i,
         inCurrentMonth: true,
-        isPeriodDay: isPeriodDay(p),
+        isPeriodDay: isMenstruating && isPeriodDay(p),
         isSpecialDay: isMenstruating ? isCheckupDay(p) : i === periodDay,
       });
     }
@@ -161,7 +184,7 @@ export function CalendarComponent({
         p,
         date: i,
         inCurrentMonth: false,
-        isPeriodDay: isPeriodDay(p),
+        isPeriodDay: isMenstruating && isPeriodDay(p),
         isSpecialDay: isMenstruating ? isCheckupDay(p) : i === periodDay,
       });
     }


### PR DESCRIPTION
…om I menstruation to I do not menstruation. 

Overall:
   - Modified the navigation flow when user selects "I menstruate"
   - Instead of going back to the settings page, now it:
     - Saves the menstruation setting
     - Navigates directly to the home page (`/`) where the calendar is displayed
     - Matches the behavior of the "I do not menstruate" option and "I menstruate" option to make the flow consistent between both "I menstruate" and "I do not menstruate". 
   - Show a fresh calendar ready for date selection when switching to "I menstruate" mode

